### PR TITLE
Make paths variable more precise

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
         # Debian vars file.
         - Debian.yml
       paths:
-        - "vars"
+        - "{{ role_path }}/vars"
 
 - name: Install Xfce desktop environment
   package:


### PR DESCRIPTION
## 🗣 Description

This pull request fixes a path issue that could cause this role to pick up the vars files from a parent role that is using it.  I ran into this specific error case today with [cisagov/ansible-role-openvpn](https;//github.com/cisagov/ansible-role-openvpn), which has [cisagov/ansible-role-pip](https://github.com/cisagov/ansible-role-pip) as a dependency.

## 💭 Motivation and Context

The path issue can cause problems if another role has this one as a dependency.  It must be fixed.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
