### PR TITLE
Add Kali Specific package Information

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,6 +22,8 @@ platforms:
   #   image: fedora:30
   - name: fedora31
     image: fedora:31
+  - name: kali
+    image: kalilinux/kali-rolling
 provisioner:
   name: ansible
   lint:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,13 +6,11 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
-        # The OS family and distribution for Kali is "Kali GNU/Linux",
-        # which is not an allowable file name in Linux due to the
-        # slash.  We will allow Kali to fall through and use the
-        # Debian vars file.
-        - Debian.yml
+        # Add regex_replace() filters to remove spaces and slashes. This allows
+        # the OS family/distribution for Kali, "Kali GNU/Linux", to be easily
+        # mapped to a vars file.
+        - "{{ ansible_distribution | regex_replace('[ /]', '_') }}.yml"
+        - "{{ ansible_os_family | regex_replace('[ /]', '_') }}.yml"
       paths:
         - "vars"
 

--- a/vars/Kali_GNU_Linux.yml
+++ b/vars/Kali_GNU_Linux.yml
@@ -1,0 +1,6 @@
+---
+# vars file for Kali
+
+# The Xfce package names
+package_names:
+  - kali-desktop-xfce


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This small PR adds a separate var file for Kali Linux which installs the `kali-desktop-xfce` meta package. The Kali Docker image was added to the `molecule` configuration for testing.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
If this role is used for deployment and/or testing I wanted the xfce4 installation to accurately mirror what would be seen in a regular Kali image. Although the Debian package works, there are a number of items in the meta package that Kali packages might rely on that would need to be installed anyway.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Local `pre-commit` and `molecule test` runs completed with no issues.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
