### PR TITLE
Add package missing on Kali Linux and Debian Bullseye

### DIFF
--- a/files/xstartup
+++ b/files/xstartup
@@ -1,4 +1,0 @@
-#!/bin/sh
-unset SESSION_MANAGER
-unset DBUS_SESSION_BUS_ADDRESS
-exec startxfce4

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -16,11 +16,16 @@ def test_packages(host):
     pkgs = None
     if (
         host.system_info.distribution == "debian"
-        or host.system_info.distribution == "ubuntu"
-    ):
+        and host.system_info.distribution != "bullseye"
+    ) or host.system_info.distribution == "ubuntu":
         pkgs = ["xfce4", "xfce4-goodies"]
+    elif (
+        host.system_info.distribution == "debian"
+        and host.system_info.distribution == "bullseye"
+    ):
+        pkgs = ["dbus-x11", "xfce4", "xfce4-goodies"]
     elif host.system_info.distribution == "kali":
-        pkgs = ["kali-desktop-xfce", "xfce4-goodies"]
+        pkgs = ["dbus-x11", "kali-desktop-xfce", "xfce4-goodies"]
     elif host.system_info.distribution == "fedora":
         # We can't check for the metapackage
         # @xfce-desktop-environment, so we check for a key xfce

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   vars:
     params:
       files:
-        - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
         - "{{ ansible_distribution }}.yml"
         - "{{ ansible_os_family }}.yml"
       paths:

--- a/vars/Debian_bullseye.yml
+++ b/vars/Debian_bullseye.yml
@@ -1,8 +1,8 @@
 ---
 # The Xfce package names
 package_names:
-  # This package is missing on Kali Linux.  See
+  # This package is missing on Debian Bullseye.  See
   # cisagov/ansible-role-xfce#9 for details.
   - dbus-x11
-  - kali-desktop-xfce
+  - xfce4
   - xfce4-goodies


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the package `dbus-x11`, which is required for the xfce4 desktop to function but is not pulled in as a dependency on Kali Linux or Debian Bullseye.

## 💭 Motivation and Context ##

Resolves #9.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
