### PR TITLE
Add missing package for Debian Bookworm and later

### DIFF
--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -17,7 +17,7 @@ def test_packages(host):
     pkgs = None
     if (
         distribution in ["debian"] and host.system_info.codename in ["buster"]
-    ) or host.system_info.distribution in ["ubuntu"]:
+    ) or distribution in ["ubuntu"]:
         pkgs = ["xfce4", "xfce4-goodies"]
     elif distribution in ["debian"]:
         pkgs = ["dbus-x11", "xfce4", "xfce4-goodies"]

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -13,27 +13,24 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_packages(host):
     """Test that the appropriate packages were installed."""
+    distribution = host.system_info.distribution
     pkgs = None
     if (
-        host.system_info.distribution == "debian"
-        and host.system_info.codename != "bullseye"
-    ) or host.system_info.distribution == "ubuntu":
+        distribution in ["debian"] and host.system_info.codename in ["buster"]
+    ) or host.system_info.distribution in ["ubuntu"]:
         pkgs = ["xfce4", "xfce4-goodies"]
-    elif (
-        host.system_info.distribution == "debian"
-        and host.system_info.codename == "bullseye"
-    ):
+    elif distribution in ["debian"]:
         pkgs = ["dbus-x11", "xfce4", "xfce4-goodies"]
-    elif host.system_info.distribution == "kali":
+    elif distribution == "kali":
         pkgs = ["dbus-x11", "kali-desktop-xfce", "xfce4-goodies"]
-    elif host.system_info.distribution == "fedora":
+    elif distribution in ["fedora"]:
         # We can't check for the metapackage
         # @xfce-desktop-environment, so we check for a key xfce
         # package.
         pkgs = ["xfce4-panel"]
     else:
         # This is an unknown OS, so force the test to fail
-        assert False
+        assert False, f"Unknown distribution {distribution}"
 
     for pkg in pkgs:
         assert host.package(pkg).is_installed

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 # The Xfce package names
 package_names:
+  # This package is missing on Debian Bullseye.  See
+  # cisagov/ansible-role-xfce#9 for details.
+  - dbus-x11
   - xfce4
   - xfce4-goodies

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 # The Xfce package names
 package_names:
-  # This package is missing on Debian Bullseye.  See
+  # This package is missing on Debian Bullseye and later.  See
   # cisagov/ansible-role-xfce#9 for details.
   - dbus-x11
   - xfce4

--- a/vars/Debian_bullseye.yml
+++ b/vars/Debian_bullseye.yml
@@ -1,8 +1,0 @@
----
-# The Xfce package names
-package_names:
-  # This package is missing on Debian Bullseye.  See
-  # cisagov/ansible-role-xfce#9 for details.
-  - dbus-x11
-  - xfce4
-  - xfce4-goodies

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,0 +1,5 @@
+---
+# The Xfce package names
+package_names:
+  - xfce4
+  - xfce4-goodies


### PR DESCRIPTION
## 🗣 Description ##

This pull request extends to Debian Bullseye and later a change that was made only to Debian Bullseye in #10.

## 💭 Motivation and context ##

In #10 we added the `dbus-x11` system package for Debian Bullseye, but Debian Bookworm needs it too.

## 🧪 Testing ##

All automated tests pass.  I also built a new Debian Desktop staging AMI with these changes, deployed it to env6 in our staging COOL environment, and verified that it functions as expected.  It did not function as expected without these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.