### PR TITLE
Remove code that disables screen locking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,10 +201,10 @@ jobs:
         scenario:
           - default
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      #   with:
+      #     # Uses the organization variable unless overridden
+      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,3 @@
 - name: Install Xfce desktop environment
   ansible.builtin.package:
     name: "{{ package_names }}"
-
-# TODO: Does this need to be generalized?  Should it be broken out
-# into a separate role?  See this issue:
-# https://github.com/cisagov/ansible-role-xfce/issues/7
-- name: Disable screen locking
-  ansible.builtin.file:
-    path: /etc/xdg/autostart/light-locker.desktop
-    state: absent


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the Ansible code that was disabling screen locking.

## 💭 Motivation and context ##

The code that was here no longer works, and in any event screen locking is disabled correctly in [cisagov/ansible-role-vnc-server](https://github.com/cisagov/ansible-role-vnc-server) as of cisagov/ansible-role-vnc-server#56.

Together with cisagov/ansible-role-vnc-server#56, this pull request resolves #7.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.